### PR TITLE
Fix comparisons with string and possible keyword

### DIFF
--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -455,7 +455,7 @@
         (case (:f op)
           :isolate (dorun
                      (real-pmap (fn [[node conn]]
-                                  (when (= node (primary conn))
+                                  (when (= (name node) (primary conn))
                                     (info node "believes itself a primary")
                                     (->> (nemesis/split-one node (:nodes test))
                                          nemesis/complete-grudge
@@ -469,7 +469,7 @@
                                 conns))
           :kill (dorun
                   (real-pmap (fn [[node conn]]
-                               (when (= node (primary conn))
+                               (when (= (name node) (primary conn))
                                  (info node "believes itself a primary")
 
                                  (c/with-session node (get (:sessions test)


### PR DESCRIPTION
If `--node` wasn't specified on the command line, then a vector of keywords `:default-nodes` is used for representing the nodes.

@aphyr, I discovered this issue while working to integrate libfaketime into MongoDB's Jepsen tests because I wasn't seeing failures when I had expected to. After looking through the logs and learning more about Clojure's equality semantics, it became clear to me why the nemesis wasn't hitting those branches. Given that the default invocation makes the `:primary-divergence-nemesis` nemesis not do anything useful, I wanted to get this issue addressed separately from my other intended changes.

I also thought about resolving this issue with the following patch, but wasn't sure if you'd have a preference.

```diff
diff --git a/src/jepsen/mongodb/core.clj b/src/jepsen/mongodb/core.clj
index c9ff4ac..4417f26 100644
--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -447,7 +447,7 @@
   (reify client/Client
     (setup! [this test _]
       (primary-divergence-nemesis
-        (into {} (real-pmap (juxt identity await-conn) (:nodes test)))))
+        (into {} (real-pmap (juxt name await-conn) (:nodes test)))))
 
     (invoke! [this test op]
       (assoc
```

**How I tested my change**

- [x] Verified that [the "<node> believes itself a primary" message](https://github.com/jepsen-io/mongodb/blob/992bfad3de33c356ee05b0fc9e50655571611b39/src/jepsen/mongodb/core.clj#L459) appeared in the logs when running both

  * `lein run test --test set` and
  * `lein run test --test set --node n1 --node n2 --node n3 --node n4 --node n5`
