### PR TITLE
Add support for using libfaketime to skew the clock

### DIFF
--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -5,6 +5,7 @@
             [clojure.pprint :refer [pprint]]
             [clojure.tools.logging :refer [debug info warn]]
             [clojure.walk :as walk]
+            [clj-time.core :as time]
             [jepsen [core      :as jepsen]
                     [db        :as db]
                     [util      :as util :refer [meh
@@ -26,6 +27,7 @@
             [jepsen.nemesis.time :as nt]
             [jepsen.control [util :as cu]]
             [jepsen.os.debian :as debian]
+            [jepsen.mongodb.time :as mt]
             [jepsen.mongodb.mongo :as m]
             [knossos [core :as knossos]
                      [model :as model]])
@@ -79,14 +81,15 @@
 
 (defn start!
   "Starts Mongod"
-  [test node]
+  [clock test node]
   (c/sudo username
-          (cu/start-daemon! {:logfile "/opt/mongodb/stdout.log"
-                             :pidfile "/opt/mongodb/pidfile"
-                             :remove-pidfile? false
-                             :chdir   "/opt/mongodb"}
-                            "/opt/mongodb/bin/mongod"
-                            :--config "/opt/mongodb/mongod.conf"))
+          (apply cu/start-daemon!
+                 {:logfile "/opt/mongodb/stdout.log"
+                  :pidfile "/opt/mongodb/pidfile"
+                  :remove-pidfile? false
+                  :chdir   "/opt/mongodb"}
+                 (conj (mt/wrap! clock "/opt/mongodb/bin/mongod")
+                       :--config "/opt/mongodb/mongod.conf")))
   :started)
 
 (defn stop!
@@ -317,17 +320,17 @@
 
 (defn db
   "MongoDB for a particular HTTP URL"
-  [url]
+  [clock url]
   (reify db/DB
     (setup! [_ test node]
       (util/timeout 300000
                     (throw (RuntimeException.
                              (str "Mongo setup on " node " timed out!")))
                     (debian/install [:libc++1 :libsnmp30])
-                    (nt/install!)
+                    (mt/init! clock)
                     (install! node url)
                     (configure! test node)
-                    (start! test node)
+                    (start! clock test node)
                     (join! test node)))
 
     (teardown! [_ test node]
@@ -373,8 +376,10 @@
 
 (defn kill-nem
   "A nemesis that kills/restarts Mongo on randomly selected nodes."
-  []
-  (nemesis/node-start-stopper random-nonempty-subset stop! start!))
+  [clock]
+  (nemesis/node-start-stopper random-nonempty-subset
+                              stop!
+                              (partial start! clock)))
 
 (defn pause-nem
   "A nemesis that pauses Mongo on randomly selected nodes."
@@ -383,10 +388,10 @@
 
 (defn clock-skew-nem
   "Skews clocks on a random subset of nodes by dt seconds."
-  [dt]
+  [clock dt]
   (reify client/Client
     (setup! [this test _]
-      (nt/reset-time! test)
+      (c/with-test-nodes test (mt/reset-time! clock))
       this)
 
     (invoke! [this test op]
@@ -394,13 +399,13 @@
              (case (:f op)
                :start (c/with-test-nodes test
                         (if (< (rand) 0.5)
-                          (do (nt/bump-time! (* 1000 dt))
+                          (do (mt/bump-time! clock (time/seconds dt))
                               dt)
                           0))
-               :stop (info c/*host* "clock reset:" (nt/reset-time! test)))))
+               :stop (info c/*host* "clock reset:" (mt/reset-time! clock)))))
 
     (teardown! [this test]
-      (nt/reset-time! test))))
+      (c/with-test-nodes test (mt/reset-time! clock)))))
 
 (defn nemesis-gen
   "Given a nemesis name, builds a generator that emits [:name-start,
@@ -442,11 +447,12 @@
 
   3. Heal the network and restart all nodes. p2 may have committed writes, but
   p1's higher optime will allow it to win the election."
-  ([] (primary-divergence-nemesis nil))
-  ([conns]
+  ([clock] (primary-divergence-nemesis clock nil))
+  ([clock conns]
   (reify client/Client
     (setup! [this test _]
       (primary-divergence-nemesis
+        clock
         (into {} (real-pmap (juxt identity await-conn) (:nodes test)))))
 
     (invoke! [this test op]
@@ -464,7 +470,7 @@
 
                                     (c/with-session node (get (:sessions test)
                                                               node)
-                                      (nt/bump-time! 120000))
+                                      (mt/bump-time! clock (time/minutes 2)))
                                     (info node "clock advanced")))
                                 conns))
           :kill (dorun
@@ -478,11 +484,11 @@
                                  (info node "mongod killed")))
                              conns))
 
-          :stop (do (nt/reset-time! test)
+          :stop (do (c/with-test-nodes test (mt/reset-time! clock))
                     (info "Clocks reset")
                     (net/heal! (:net test) test)
                     (info "Network healed")
-                    (c/on-nodes test start!)
+                    (c/on-nodes test (partial start! clock))
                     (info "Nodes restarted")))))
 
     (teardown! [this test]
@@ -512,8 +518,8 @@
            :name            (str "mongodb " name " s:" (:storage-engine opts)
                                  " p:" (:protocol-version opts))
            :os              debian/os
-           :db              (db (:tarball opts))
-           :nemesis         (primary-divergence-nemesis)
+           :db              (db (:clock opts) (:tarball opts))
+           :nemesis         (primary-divergence-nemesis (:clock opts))
            :generator       (gen/phases
                               (->> (:generator opts)
                                    (gen/nemesis (primary-divergence-gen))
@@ -525,4 +531,5 @@
                                 (:final-generator opts))))
     (dissoc opts
             :generator
-            :final-generator)))
+            :final-generator
+            :clock)))

--- a/src/jepsen/mongodb/faketime.clj
+++ b/src/jepsen/mongodb/faketime.clj
@@ -1,0 +1,68 @@
+(ns jepsen.mongodb.faketime
+  "Functions for messing with time and clocks."
+  (:require [clj-time.core :as time]
+            [jepsen.control :as c]
+            [jepsen.mongodb.time :as mt])
+  (:import (java.nio.charset Charset)
+           (java.nio.file Files)
+           (java.nio.file OpenOption)
+           (java.nio.file StandardOpenOption)
+           (java.nio.file.attribute FileAttribute)
+           (java.nio.file.attribute PosixFilePermissions)
+           (org.joda.time Period)))
+
+(defn- upload-faketimerc!
+  "Updates the /opt/jepsen/faketimerc configuration file."
+  [^Period offset]
+  (c/su
+    (let [tmp-file
+          (Files/createTempFile
+            "jepsen-upload"
+            ".faketimerc"
+            (into-array FileAttribute [(PosixFilePermissions/asFileAttribute
+                                         (PosixFilePermissions/fromString
+                                           "rw-r--r--"))]))]
+      (try
+        (Files/write tmp-file
+                     ; libfaketime requires a leading '+' for setting offsets
+                     ; ahead of the true time.
+                     [(format "%+d" (time/in-seconds offset))]
+                     (Charset/defaultCharset)
+                     (into-array OpenOption [StandardOpenOption/WRITE]))
+        ; Upload
+        (c/exec :mkdir :-p "/opt/jepsen")
+        (c/exec :chmod "a+rwx" "/opt/jepsen")
+        (c/upload (str tmp-file) "/opt/jepsen/faketimerc")
+        (finally
+          (Files/delete tmp-file))))))
+
+(defn- add-periods [a b] (.plus (.toPeriod a) (.toPeriod b)))
+
+(defn clock
+  "Performs clock skewing using libfaketime and its file-based configuration
+  mechanism."
+  ([{:keys [libfaketime-path]}]
+   (let [state (atom {})
+         true-time (time/seconds 0)]
+     (reify mt/Clock
+       (init! [clock]
+         (swap! state assoc c/*host* (atom true-time))
+         ; We reset the faketimerc configuration file when initializing the clock
+         ; to avoid causing heartbeat requests to time out spuriously when
+         ; initiating the replica set.
+         (upload-faketimerc! true-time))
+
+       (wrap! [clock bin]
+         (conj ["/usr/bin/env"
+                "FAKETIME_NO_CACHE=1"
+                "FAKETIME_TIMESTAMP_FILE=/opt/jepsen/faketimerc"
+                (format "LD_PRELOAD=%s" libfaketime-path)]
+                bin))
+
+       (bump-time! [clock delta]
+         (upload-faketimerc! (swap! (get @state c/*host*)
+                                    (partial add-periods delta))))
+
+       (reset-time! [clock]
+         (upload-faketimerc! (swap! (get @state c/*host*)
+                                    (constantly true-time))))))))

--- a/src/jepsen/mongodb/time.clj
+++ b/src/jepsen/mongodb/time.clj
@@ -1,0 +1,40 @@
+(ns jepsen.mongodb.time
+  "Controls time and clocks."
+  (:require [clj-time.core :as time]
+            [jepsen.nemesis.time :as nt])
+  (:import (org.joda.time Period)))
+
+(defprotocol Clock
+  (init!
+    [clock]
+    "Initializes any internal structures for time keeping on the current host.")
+
+  (wrap!
+    [clock bin]
+    "Returns how to invoke the specified binary under the control of this
+    clock.")
+
+  (bump-time!
+    [clock ^Period delta]
+    "Advances the current host's clock by the specified time period.")
+
+  (reset-time! [clock]
+               "Resets the current host's clock back to the true time."))
+
+(defn noop-clock
+  "Does nothing."
+  ([_]
+   (reify Clock
+     (init! [clock])
+     (wrap! [clock bin] [bin])
+     (bump-time! [clock delta])
+     (reset-time! [clock]))))
+
+(defn system-clock
+  "Changes the system's time using settimeofday()."
+  ([_]
+   (reify Clock
+     (init! [clock])
+     (wrap! [clock bin] [bin])
+     (bump-time! [clock delta] (nt/bump-time! (time/in-millis delta)))
+     (reset-time! [clock] (nt/reset-time!)))))


### PR DESCRIPTION
* Introduces a `Clock` protocol for controlling the clock.
* Defines a `faketime/clock` instance that uses a faketimerc configuration file to change the time.
* Defines a `time/system-clock` instance that uses `jepsen.nemesis.time/bump-time!` to change the time.

**Note**: The `--libfaketime-path` command line option defaults to `/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1` for compatibility with where the shared object is installed by the `libfaketime` package on Debian. However, the packaged versions [for trusty (0.9.5-2)](http://packages.ubuntu.com/trusty/utils/libfaketime) and [for xenial (0.9.6-4)](http://packages.ubuntu.com/xenial/utils/libfaketime) aren't sufficient for running with `--clock-skew=faketime`. A script similar to the following is used to build [libfaketime](https://github.com/wolfcw/libfaketime) from source with `--libfaketime-path=/opt/mongodb/libfaketime.so.1` specified on the command line.

```shell
# Build libfaketime. A version of libfaketime at least as new as v0.9.6-9-g75896bd is required to
# use the FAKETIME_NO_CACHE and FAKETIME_TIMESTAMP_FILE environment variables.
git clone git@github.com:wolfcw/libfaketime.git
cd libfaketime
git checkout 3c0ce9c8859ed136a154b61da396deece94844e0
make PREFIX=$(pwd)/build/ LIBDIRNAME='.' install

# Add libfaketime to mongodb-binaries.tgz so it gets uploaded to each of the LXC containers. The
# build/ prefix of the shared object will get removed when Jepsen extracts the tarball into the
# /opt/mongodb/ directory.
gzip --stdout --decompress mongodb-binaries.tgz > mongodb-binaries.tar
tar --append --file=mongodb-binaries.tar build/libfaketime.so.1
gzip --stdout mongodb-binaries.tar > mongodb-binaries.tgz
```

@aphyr, I think it would be nice to add `:clock` to [the list of keys that cannot be serialized by fressian](https://github.com/jepsen-io/jepsen/blob/0.1.4/jepsen/src/jepsen/store.clj#L155-L157) - I ended up adding the clock as a parameter to the nemesis functions since I couldn't have it be part of the test instance. I'm not sure it's worth exposing a way to inject additional keys into that list, but I also didn't see a way to set, and then unset, keys [like is done in `jepsen.core/run!`](https://github.com/jepsen-io/jepsen/blob/0.1.4/jepsen/src/jepsen/core.clj#L408-L414).

Additionally, I suspect you may want to have the `Clock` protocol committed to the jepsen-io/jepsen repository, but I didn't want to try and synchronize multiple commits on separate repositories given how we want to switch over to using jepsen-io/mongodb and unblock testing for rollback improvements.

**How I tested my changes**

- [x] Verified that I could reproduce the failures with

  * Replication protocol version 0 and MongoDB version 3.4.0-rc3
  * Replication protocol version 1 and MongoDB version 3.4.0-rc3
  * Replication protocol version 1 and MongoDB version 3.4.0-rc4

  when using `--clock-skew=faketime`.