### PR TITLE
Dynamically set enableMajorityReadConcern option

### DIFF
--- a/resources/mongod.conf
+++ b/resources/mongod.conf
@@ -19,4 +19,4 @@ storage:
 
 replication:
   replSetName: jepsen
-  enableMajorityReadConcern: true
+  enableMajorityReadConcern: %ENABLE_MAJORITY_READ_CONCERN%

--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -74,7 +74,10 @@
   (c/sudo username
           (c/exec :echo (-> "mongod.conf" io/resource slurp
                             (str/replace #"%STORAGE_ENGINE%"
-                                         (:storage-engine test)))
+                                         (:storage-engine test))
+                            (str/replace #"%ENABLE_MAJORITY_READ_CONCERN%"
+                                         (str (= (:read-concern test)
+                                                 :majority))))
                   :> "/opt/mongodb/mongod.conf")))
 
 (defn start!


### PR DESCRIPTION
The MMAPv1 storage engine doesn't support `{readConcern: "majority"}`, so mongod will refuse to start up with `--enableMajorityReadConcern` when `--storageEngine=mmapv1` is also specified.

```
2017-03-23T14:17:29.164-0400 I CONTROL  [initandlisten] options: { config: "/opt/mongodb/mongod.conf", replication: { enableMajorityReadConcern: true, replSetName: "jepsen" }, storage: { dbPath: "/opt/mongodb/data", engine: "mmapv1", journal: { enabled: true }, mmapv1: { preallocDataFiles: false, smallFiles: true } }, systemLog: { destination: "file", logAppend: true, path: "/opt/mongodb/mongod.log", verbosity: 1 } }
...
2017-03-23T14:17:29.509-0400 F STORAGE  [initandlisten] Majority read concern requires a storage engine that supports snapshots, such as wiredTiger. mmapv1 does not support snapshots.
...
2017-03-23T14:17:29.613-0400 I CONTROL  [initandlisten] shutting down with code:2
```

@aphyr, this changes the `mongod.conf` file to specify `enableMajorityReadConcern: true` only when `--read-concern majority` is specified on the command line.

**How I tested my change**

- [x] Verified that I could successfully run `lein run test --test register --storage-engine mmapv1`.