### PR TITLE
Bind mongod to all IPv4 network interfaces

### DIFF
--- a/resources/mongod.conf
+++ b/resources/mongod.conf
@@ -4,6 +4,9 @@ systemLog:
   path: /opt/mongodb/mongod.log
   verbosity: 1
 
+net:
+  bindIp: 0.0.0.0
+
 storage:
   dbPath: /opt/mongodb/data
   journal:


### PR DESCRIPTION
The work in SERVER-28229 will cause mongod processes to bind to localhost by default. Jepsen appears to be opening non-localhost connections, so this change will cause our Jepsen tests to be unable to connect to the clusters they spawn. The solution is to cause Jepsen spawned mongods to bind to '0.0.0.0'. This will be forwards compatible with SERVER-28229, and backwards compatible with older releases.

- [x] Verified that I could successfully run  `lein run test --test set`.
- [x] Verified that I could successfully run  `lein run test --test register`.