### PR TITLE
Avoid starting new mongod process when one is still running

### DIFF
--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -87,11 +87,17 @@
   [clock test node]
   (c/sudo username
           (apply cu/start-daemon!
-                 {:logfile "/opt/mongodb/stdout.log"
+                 {:chdir "/opt/mongodb"
+                  :background? false
+                  :logfile "/opt/mongodb/stdout.log"
+                  :make-pidfile? false
+                  :match-executable? false
+                  :match-process-name? true
                   :pidfile "/opt/mongodb/pidfile"
-                  :remove-pidfile? false
-                  :chdir   "/opt/mongodb"}
+                  :process-name "mongod"}
                  (conj (mt/wrap! clock "/opt/mongodb/bin/mongod")
+                       :--fork
+                       :--pidfilepath "/opt/mongodb/pidfile"
                        :--config "/opt/mongodb/mongod.conf")))
   :started)
 


### PR DESCRIPTION
This prevents spurious "SERVER RESTARTED" messages from appearing in the `mongod.log` file when running with `--clock-skew=faketime` and also avoids causing the `mongod.log` file from being rotated unnecessarily (if running with `systemLog.logAppend=false`).

The changes in this pull request depend on the changes in jepsen-io/jepsen#176. @aphyr, please let me know if I should preemptively bump the version of [the jepsen-io/jepsen dependency in `project.clj`](https://github.com/jepsen-io/mongodb/blob/dd1dfb8b646752f32efca233c0dfd871504a4b27/project.clj#L8) as I wasn't quite sure how to handle requiring changes from a version of Jepsen that has yet to be released.