### PR TITLE
Update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,12 @@
 (defproject jepsen.mongodb "0.2.1-SNAPSHOT"
   :description "Jepsen MongoDB tests"
-  :url "https://github.com/aphyr/jepsen"
+  :url "https://github.com/jepsen-io/mongodb"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.cli "0.3.3"]
-                 [jepsen "0.1.4-SNAPSHOT"]
-                 [org.mongodb/mongodb-driver "3.4.0-rc1"]]
+                 [org.clojure/tools.cli "0.3.5"]
+                 [jepsen "0.1.6-SNAPSHOT"]
+                 [org.mongodb/mongodb-driver "3.4.2"]]
   :jvm-opts ["-Xmx16g"
              "-Xms16g"
              "-Xmn4g"


### PR DESCRIPTION
The changes from 06bcc0594c6d0ed913cc6f64d4f71c0ba7a88084 depend on the changes from jepsen-io/jepsen@1146f081f6877db90fcfb6b2d87ff814678d7be6.

> Make sure you bump your dependency in the mongo tests to 0.1.6-SNAPSHOT. :)
>
> jepsen-io/jepsen#176

@aphyr, would you mind deploying version 0.1.6-SNAPSHOT of jepsen-io/jepsen:jepsen to Clojars?