### PR TITLE
Add support for running tests without any virtualization

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen.mongodb "0.2.1"
+(defproject jepsen.mongodb "0.2.2-SNAPSHOT"
   :description "Jepsen MongoDB tests"
   :url "https://github.com/jepsen-io/mongodb"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject jepsen.mongodb "0.2.1-SNAPSHOT"
+(defproject jepsen.mongodb "0.2.1"
   :description "Jepsen MongoDB tests"
   :url "https://github.com/jepsen-io/mongodb"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.5"]
-                 [jepsen "0.1.6-SNAPSHOT"]
+                 [jepsen "0.1.8"]
                  [org.mongodb/mongodb-driver "3.4.2"]]
   :jvm-opts ["-Xmx16g"
              "-Xms16g"

--- a/resources/mongod.conf
+++ b/resources/mongod.conf
@@ -1,14 +1,17 @@
 systemLog:
   destination: file
   logAppend: true
-  path: /opt/mongodb/mongod.log
+  path: %PATH_PREFIX%/mongod.log
   verbosity: 1
 
 net:
   bindIp: 0.0.0.0
 
+setParameter:
+  enableTestCommands: true
+
 storage:
-  dbPath: /opt/mongodb/data
+  dbPath: %PATH_PREFIX%/data
   journal:
     enabled: true
 #   commitIntervalMs: 1000 # might want to verify journal loss windows

--- a/src/jepsen/control/local.clj
+++ b/src/jepsen/control/local.clj
@@ -1,0 +1,57 @@
+(ns jepsen.control.local
+  "Functions for running commands against the local host.
+
+  This namespace presents an API similar to that of the `jepsen.control`
+  namespace with the behavioral difference being these functions run commands
+  against the local host (via bash) rather than the remote host (via bash over
+  the node's SSH connection)."
+  (:require [clojure.string :as str]
+            [clojure.java.shell :as shell]
+            [jepsen.control :as c]))
+
+(defn wrap-sudo
+  "Wraps command in a sudo subshell."
+  [cmd]
+  (if c/*sudo*
+    (merge cmd {:cmd `("sudo" "-S" "-u" ~c/*sudo* "--" ~@(:cmd cmd))
+                :in  (if c/*password*
+                       (str c/*password* "\n" (:in cmd))
+                       (:in cmd))})
+    cmd))
+
+(defn wrap-bash
+  "Wraps command in a bash shell."
+  [cmd]
+  (assoc cmd :cmd `("bash" "-c" ~(str/join " " (:cmd cmd)))))
+
+(defn wrap-cd
+  "Wraps command by changing to the current bound directory first."
+  [cmd]
+  (if c/*dir*
+    (assoc cmd :dir c/*dir*)
+    cmd))
+
+(defn sh*
+  "Evaluates a shell command."
+  [{cmd :cmd, :as action}]
+  (apply shell/sh (concat cmd (mapcat identity (dissoc action :cmd)))))
+
+(defn exec*
+  "Like exec, but does not escape."
+  [& commands]
+  (-> (array-map :cmd commands)
+      wrap-cd
+      wrap-bash
+      wrap-sudo
+      c/wrap-trace
+      sh*
+      c/throw-on-nonzero-exit
+      c/just-stdout))
+
+(defn exec
+  "Takes a shell command and arguments, runs the command on the local host,
+  and returns its stdout, throwing if an error occurs. Escapes all arguments."
+  [& commands]
+  (->> commands
+       (map c/escape)
+       (apply exec*)))

--- a/src/jepsen/mongodb/cluster.clj
+++ b/src/jepsen/mongodb/cluster.clj
@@ -1,0 +1,189 @@
+(ns jepsen.mongodb.cluster
+  "Functions for starting and stopping MongoDB deployments."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.logging :refer [info]]
+            [jepsen.control :as c]
+            [jepsen.mongodb.control :as mcontrol]
+            [jepsen.mongodb.mongo :as m]
+            [jepsen.mongodb.time :as mt]
+            [jepsen.mongodb.util :as mu]))
+
+;; Copied from the jepsen.control.util/start-daemon! function of
+;; Jepsen version 0.1.8 with the `exec` function calls replaced with
+;; `mcontrol/exec` function calls to account for the possibility of running
+;; without any virtualization.
+(defn- start-daemon!
+  "Starts a daemon process, logging stdout and stderr to the given file.
+  Invokes `bin` with `args`. Options are:
+
+  :background?
+  :chdir
+  :logfile
+  :make-pidfile?
+  :match-executable?
+  :match-process-name?
+  :pidfile
+  :process-name"
+  [test opts bin & args]
+  (info "starting" (.getName (io/file (name bin))))
+  (mcontrol/exec test
+                 :echo (c/lit "`date +'%Y-%m-%d %H:%M:%S'`")
+                 "Jepsen starting" bin (str/join " " args)
+                 :>> (:logfile opts))
+  (apply mcontrol/exec test
+         :start-stop-daemon :--start
+         (when (:background? opts true) [:--background :--no-close])
+         (when (:make-pidfile? opts true) :--make-pidfile)
+         (when (:match-executable? opts true) [:--exec bin])
+         (when (:match-process-name? opts false)
+           [:--name (:process-name opts (.getName (io/file bin)))])
+         :--pidfile  (:pidfile opts)
+         :--chdir    (:chdir opts)
+         :--oknodo
+         :--startas  bin
+         :--
+         (concat args [:>> (:logfile opts) (c/lit "2>&1")])))
+
+;; The jepsen.control.util/stop-daemon! function uses the kill -9 command to
+;; terminate the process associated with the pidfile. We would rather send a
+;; SIGTERM to the process in order to be able to detect hangs the may occur
+;; during a clean shutdown.
+(defn- stop-daemon!
+  "Sends a daemon process identified by its pidfile a SIGTERM and waits until
+  the process exits."
+  [test pidfile]
+  (info "stopping" pidfile)
+  (mcontrol/exec test
+                 :start-stop-daemon :--stop
+                 :--pidfile pidfile
+                 ; We wait in increments of 60 seconds to avoid busy-waiting if
+                 ; the process is actually hung.
+                 :--retry "TERM/forever/60"
+                 :--oknodo))
+
+(defn- kill-daemon!
+  "Sends a daemon process identified by its pidfile a SIGKILL and waits until
+  the process exits."
+  [test pidfile]
+  (info "killing" pidfile)
+  (mcontrol/exec test
+                 :start-stop-daemon :--stop
+                 :--pidfile pidfile
+                 :--retry "KILL/forever/0"
+                 :--oknodo))
+
+;;
+;; init! methods
+;;
+
+(defmulti init! (fn [test node] (:virt test)))
+
+(defn- write-config-file!
+  [test node]
+  (mcontrol/exec test
+    :echo (-> "mongod.conf" io/resource slurp
+              (str/replace #"%ENABLE_MAJORITY_READ_CONCERN%"
+                           (str (= (:read-concern test) :majority)))
+              (str/replace #"%PATH_PREFIX%" (mu/path-prefix test node))
+              (str/replace #"%STORAGE_ENGINE%" (:storage-engine test)))
+    :> (mu/path-prefix test node "/mongod.conf")))
+
+(defmethod init! :none [test node]
+  (write-config-file! test node))
+
+(defmethod init! :vm [test node]
+  (c/sudo (:username test) (write-config-file! test node)))
+
+;;
+;; start! methods
+;;
+
+(defmulti start! (fn [clock test node] (:virt test)))
+
+(defn- start-mongod!
+  [clock test node port]
+  (apply start-daemon! test
+         {:chdir (mu/path-prefix test node)
+          :background? false
+          :logfile (mu/path-prefix test node "/stdout.log")
+          :make-pidfile? false
+          :match-executable? false
+          :match-process-name? true
+          :pidfile (mu/path-prefix test node "/mongod.pid")
+          :process-name "mongod"}
+         (conj (mt/wrap! clock test (mu/path-prefix test node "/bin/mongod"))
+               :--fork
+               :--pidfilepath (mu/path-prefix test node "/mongod.pid")
+               :--port port
+               :--config (mu/path-prefix test node "/mongod.conf"))))
+
+(defn- start-mongobridge!
+  [test node dest]
+  (start-daemon! test {:chdir (mu/path-prefix test node)
+                       :background? true
+                       :logfile (mu/path-prefix test node "/bridge.log")
+                       :make-pidfile? true
+                       :match-executable? false
+                       :match-process-name? true
+                       :pidfile (mu/path-prefix test node "/bridge.pid")
+                       :process-name "mongobridge"}
+                      (mu/path-prefix test node "/bin/mongobridge")
+                      :--port (.getPort (m/server-address node))
+                      :--dest dest
+                      :--verbose))
+
+(defmethod start! :none [clock test node]
+  (let [dest (get (:bridge test) node)]
+    (start-mongobridge! test node dest)
+    (start-mongod! clock test node (.getPort (m/server-address dest)))
+    :started))
+
+(defmethod start! :vm [clock test node]
+  (c/sudo (:username test)
+          (start-mongod! clock test node (.getPort (m/server-address node))))
+  :started)
+
+;;
+;; stop! methods
+;;
+
+(defmulti stop! (fn [test node] (:virt test)))
+
+(defn- stop-mongod!
+  [test node]
+  (stop-daemon! test (mu/path-prefix test node "/mongod.pid")))
+
+(defn- stop-mongobridge!
+  [test node]
+  (stop-daemon! test (mu/path-prefix test node "/bridge.pid")))
+
+(defmethod stop! :none [test node]
+  (stop-mongod! test node)
+  (stop-mongobridge! test node)
+  :stopped)
+
+(defmethod stop! :vm [test node]
+  (c/sudo (:username test) (stop-mongod! test node))
+  :stopped)
+
+;;
+;; kill! methods
+;;
+
+(defmulti kill! (fn [test node] (:virt test)))
+
+(defn- kill-mongod!
+  [test node]
+  (kill-daemon! test (mu/path-prefix test node "/mongod.pid")))
+
+(defmethod kill! :none [test node]
+  (kill-mongod! test node)
+  ; mongobridge doesn't have any durable state so there isn't anything to be
+  ; gained from killing it. We ask it nicely to shut down instead.
+  (stop-mongobridge! test node)
+  :stopped)
+
+(defmethod kill! :vm [test node]
+  (c/sudo (:username test) (kill-mongod! test node))
+  :stopped)

--- a/src/jepsen/mongodb/control.clj
+++ b/src/jepsen/mongodb/control.clj
@@ -1,0 +1,16 @@
+(ns jepsen.mongodb.control
+  "Utility functions."
+  (:require [jepsen.control :as c]
+            [jepsen.control.local :as local]))
+
+;;
+;; exec methods
+;;
+
+(defmulti exec (fn [test & commands] (:virt test)))
+
+(defmethod exec :none [test & commands]
+  (apply local/exec commands))
+
+(defmethod exec :vm [test & commands]
+  (apply c/exec commands))

--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -498,7 +498,7 @@
                                     (info node "believes itself a primary")
                                     (->> (nemesis/split-one node (:nodes test))
                                          nemesis/complete-grudge
-                                         (nemesis/partition! test))
+                                         (net/drop-all! test))
                                     (info node "isolated")
 
                                     (c/with-session node (get (:sessions test)

--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -27,121 +27,16 @@
             [jepsen.nemesis.time :as nt]
             [jepsen.control [util :as cu]]
             [jepsen.os.debian :as debian]
-            [jepsen.mongodb.time :as mt]
+            [jepsen.mongodb.cluster :as mc]
+            [jepsen.mongodb.control :as mcontrol]
+            [jepsen.mongodb.dbutil :as mdbutil]
             [jepsen.mongodb.mongo :as m]
+            [jepsen.mongodb.net :as mnet]
+            [jepsen.mongodb.time :as mt]
+            [jepsen.mongodb.util :as mu]
             [knossos [core :as knossos]
                      [model :as model]])
   (:import (clojure.lang ExceptionInfo)))
-
-(def username "mongodb")
-
-(defn install!
-  "Installs a tarball from an HTTP URL"
-  [node url]
-  ; Add user
-  (cu/ensure-user! username)
-
-  ; Download tarball
-  (c/su
-    (let [local-file (nth (re-find #"file://(.+)" url) 1)
-          file       (or local-file (c/cd "/tmp" (str "/tmp/" (cu/wget! url))))]
-      (try
-        (c/cd "/opt"
-              ; Clean up old dir
-              (c/exec :rm :-rf "mongodb")
-              ; Create mongodb & data dir
-              (c/exec :mkdir :-p "mongodb/data")
-              ; Extract to mongodb
-              (c/exec :tar :xvf file :-C "mongodb" :--strip-components=1)
-              ; Permissions
-              (c/exec :chown :-R (str username ":" username) "mongodb"))
-        (catch RuntimeException e
-          (condp re-find (.getMessage e)
-            #"tar: Unexpected EOF"
-            (if local-file
-              ; Nothing we can do to recover here
-              (throw (RuntimeException.
-                       (str "Local tarball " local-file " on node " (name node)
-                            " is corrupt: unexpected EOF.")))
-              (do (info "Retrying corrupt tarball download")
-                  (c/exec :rm :-rf file)
-                  (install! node url)))
-
-            ; Throw by default
-            (throw e)))))))
-
-(defn configure!
-  "Deploy configuration files to the node."
-  [test node]
-  (c/sudo username
-          (c/exec :echo (-> "mongod.conf" io/resource slurp
-                            (str/replace #"%STORAGE_ENGINE%"
-                                         (:storage-engine test))
-                            (str/replace #"%ENABLE_MAJORITY_READ_CONCERN%"
-                                         (str (= (:read-concern test)
-                                                 :majority))))
-                  :> "/opt/mongodb/mongod.conf")))
-
-(defn start!
-  "Starts Mongod"
-  [clock test node]
-  (c/sudo username
-          (apply cu/start-daemon!
-                 {:chdir "/opt/mongodb"
-                  :background? false
-                  :logfile "/opt/mongodb/stdout.log"
-                  :make-pidfile? false
-                  :match-executable? false
-                  :match-process-name? true
-                  :pidfile "/opt/mongodb/pidfile"
-                  :process-name "mongod"}
-                 (conj (mt/wrap! clock "/opt/mongodb/bin/mongod")
-                       :--fork
-                       :--pidfilepath "/opt/mongodb/pidfile"
-                       :--config "/opt/mongodb/mongod.conf")))
-  :started)
-
-(defn stop-daemon!
-  "Sends a daemon process identified by its pidfile a SIGTERM and waits until
-  the process exits."
-  [pidfile]
-  (info "stopping" pidfile)
-  (c/exec :start-stop-daemon :--stop
-          :--pidfile  pidfile
-          :--retry    "TERM/forever/0"
-          :--oknodo))
-
-(defn stop!
-  "Stops Mongod"
-  [test node]
-  (c/sudo username (stop-daemon! "/opt/mongodb/pidfile"))
-  :stopped)
-
-(defn kill!
-  "Kills Mongod"
-  [test node]
-  (cu/stop-daemon! "mongod" "/opt/mongodb/pidfile")
-  (meh (c/su (c/exec :killall :-9 "mongod")))
-  :stopped)
-
-(defn savelog!
-  "Saves Mongod log"
-  [node]
-  (info node "copying mongod.log & stdout.log file to /root/")
-  (c/su
-    (meh (c/exec :cp :-f
-                 "/opt/mongodb/mongod.log"
-                 "/opt/mongodb/stdout.log"
-                 "/root/"))))
-
-(defn wipe!
-  "Shuts down MongoDB and wipes data."
-  [test node]
-  (stop! test node)
-  (savelog! node)
-  (info node "deleting data files")
-  (c/su
-    (c/exec :rm :-rf (c/lit "/opt/mongodb/*.log"))))
 
 (defn mongo!
   "Run a Mongo shell command. Spits back an unparsable kinda-json string,
@@ -194,12 +89,6 @@
   [conn conf]
   (m/admin-command! conn :replSetReconfig conf))
 
-(defn node+port->node
-  "Take a mongo \"n1:27107\" string and return just the node as a string:
-  :n1."
-  [s]
-  ((re-find #"(.+):\d+" s) 1))
-
 (defn primaries
   "What nodes does this conn think are primaries?"
   [conn]
@@ -207,7 +96,7 @@
        :members
        (filter #(= "PRIMARY" (:stateStr %)))
        (map :name)
-       (map node+port->node)))
+       (map m/server-address)))
 
 (defn primary
   "Which single node does this conn think the primary is? Throws for multiple
@@ -262,11 +151,11 @@
   "Block until all nodes in the test are known to this connection's replset
   status"
   [test conn]
-  (while (try (not= (set (map name (:nodes test)))
+  (while (try (not= (set (map m/server-address (:nodes test)))
                     (->> (replica-set-status conn)
                          :members
                          (map :name)
-                         (map node+port->node)
+                         (map m/server-address)
                          set))
               (catch ExceptionInfo e
                 (if (re-find #"should come online shortly"
@@ -276,7 +165,8 @@
     (info :replica-set-status (with-out-str (->> (replica-set-status conn)
                                                  :members
                                                  (map :name)
-                                                 (map node+port->node)
+                                                 (map m/server-address)
+                                                 (map str)
                                                  pprint)))
     (Thread/sleep 1000)))
 
@@ -294,7 +184,7 @@
                  (map-indexed (fn [i node]
                                 {:_id  i
                                  :priority (- (count (:nodes test)) i)
-                                 :host (str (name node) ":27017")})))})
+                                 :host (str (m/server-address node))})))})
 
 (defn join!
   "Join nodes into a replica set. Blocks until any primary is visible to all
@@ -340,24 +230,44 @@
     (info node "waiting for primary")
     (await-primary conn)
 
-    (info node "primary is" (primary conn))
+    (info node "primary is" (str (primary conn)))
     (jepsen/synchronize test)))
 
 (defn db
   "MongoDB for a particular HTTP URL"
   [clock url]
-  (let [setup-called (atom false)]
+  (let [state (atom {})]
+    ; We intentionally do not implement the jepsen.db/LogFiles protocol in order
+    ; to avoid the jepsen.core/snarf-logs! function from being called when an
+    ; exception occurs or when `db` is being torn down. The
+    ; jepsen.core/snarf-logs! function uses the jepsen.control/download
+    ; function, which requires the use of an SSH connection and is therefore
+    ; incompatible with the concept of running without any virtualization. The
+    ; teardown! method is instead responsible for downloading/copying the logs
+    ; to the store/ directory.
     (reify db/DB
       (setup! [_ test node]
-        (swap! setup-called (constantly true))
+        (swap! state assoc node {:setup-called true})
         (util/timeout 300000
                       (throw (RuntimeException.
                                (str "Mongo setup on " node " timed out!")))
-                      (debian/install [:libc++1 :libsnmp30])
-                      (mt/init! clock)
-                      (install! node url)
-                      (configure! test node)
-                      (start! clock test node)
+                      (when (= :vm (:virt test))
+                        (debian/install [:libc++1 :libsnmp30]))
+
+                      ; The jepsen.mongodb.dbutil/install! function creates the
+                      ; subdirectories that the jepsen.mongodb.time/init!
+                      ; function and the jepsen.mongodb.cluster/init! function
+                      ; attempt to create files in, so it must happen first.
+                      (->> (or (some->> (:mongodb-dir test)
+                                        io/file
+                                        .getCanonicalPath
+                                        (str "file://"))
+                               url)
+                           (mdbutil/install! test node))
+
+                      (mt/init! clock test)
+                      (mc/init! test node)
+                      (mc/start! clock test node)
                       (join! test node)))
 
       (teardown! [_ test node]
@@ -366,13 +276,19 @@
         ; called. We forcibly terminate any mongod processes that may be running
         ; in order to prevent hangs from an earlier execution from causing
         ; additional failures.
-        (when (not @setup-called) (kill! test node))
-        (wipe! test node))
-
-      db/LogFiles
-      (log-files [_ test node]
-        ["/opt/mongodb/stdout.log"
-         "/opt/mongodb/mongod.log"]))))
+        (if-not (:setup-called (get @state node))
+          (mc/kill! test node)
+          ; We call the snarf-logs! function before stopping the node to match
+          ; the behavior of how jepsen.core/snarf-logs! is called before
+          ; jepsen.db/teardown! is called. This is useful for gathering at least
+          ; partial logs if mongod is going to hang during clean shutdown.
+          (do (mdbutil/snarf-logs! test node)
+              (try
+                (mc/stop! test node)
+                ; We call the snarf-logs! function after stopping the node to
+                ; ensure the shutdown messages from mongod are included in the
+                ; downloaded logs.
+                (finally (mdbutil/snarf-logs! test node)))))))))
 
 (defmacro with-errors
   "Takes an invocation operation, a set of idempotent operation functions which
@@ -411,8 +327,8 @@
   "A nemesis that kills/restarts Mongo on randomly selected nodes."
   [clock]
   (nemesis/node-start-stopper random-nonempty-subset
-                              kill!
-                              (partial start! clock)))
+                              mc/kill!
+                              (partial mc/start! clock)))
 
 (defn pause-nem
   "A nemesis that pauses Mongo on randomly selected nodes."
@@ -424,7 +340,7 @@
   [clock dt]
   (reify client/Client
     (setup! [this test _]
-      (c/with-test-nodes test (mt/reset-time! clock))
+      (c/with-test-nodes test (mt/reset-time! clock test))
       this)
 
     (invoke! [this test op]
@@ -432,13 +348,13 @@
              (case (:f op)
                :start (c/with-test-nodes test
                         (if (< (rand) 0.5)
-                          (do (mt/bump-time! clock (time/seconds dt))
+                          (do (mt/bump-time! clock test (time/seconds dt))
                               dt)
                           0))
-               :stop (info c/*host* "clock reset:" (mt/reset-time! clock)))))
+               :stop (info c/*host* "clock reset:" (mt/reset-time! clock test)))))
 
     (teardown! [this test]
-      (c/with-test-nodes test (mt/reset-time! clock)))))
+      (c/with-test-nodes test (mt/reset-time! clock test)))))
 
 (defn nemesis-gen
   "Given a nemesis name, builds a generator that emits [:name-start,
@@ -492,36 +408,34 @@
       (assoc
         op :value
         (case (:f op)
-          :isolate (dorun
+          :isolate (->> conns
+                        (real-pmap (fn [[node conn]]
+                          (when (= (m/server-address node) (primary conn))
+                            (info node "believes itself a primary")
+                            (->> (nemesis/split-one node (:nodes test))
+                                 nemesis/complete-grudge
+                                 (net/drop-all! test))
+                            (info node "isolated")
+
+                            (c/with-session node (get (:sessions test) node)
+                              (mt/bump-time! clock test (time/minutes 2)))
+                            (info node "clock advanced"))))
+                        dorun)
+
+          :kill (->> conns
                      (real-pmap (fn [[node conn]]
-                                  (when (= (name node) (primary conn))
-                                    (info node "believes itself a primary")
-                                    (->> (nemesis/split-one node (:nodes test))
-                                         nemesis/complete-grudge
-                                         (net/drop-all! test))
-                                    (info node "isolated")
+                       (when (= (m/server-address node) (primary conn))
+                         (info node "believes itself a primary")
+                         (c/with-session node (get (:sessions test) node)
+                           (mc/kill! test node))
+                         (info node "mongod killed"))))
+                     dorun)
 
-                                    (c/with-session node (get (:sessions test)
-                                                              node)
-                                      (mt/bump-time! clock (time/minutes 2)))
-                                    (info node "clock advanced")))
-                                conns))
-          :kill (dorun
-                  (real-pmap (fn [[node conn]]
-                               (when (= (name node) (primary conn))
-                                 (info node "believes itself a primary")
-
-                                 (c/with-session node (get (:sessions test)
-                                                           node)
-                                   (meh (c/su (c/exec :killall :-9 "mongod"))))
-                                 (info node "mongod killed")))
-                             conns))
-
-          :stop (do (c/with-test-nodes test (mt/reset-time! clock))
+          :stop (do (c/with-test-nodes test (mt/reset-time! clock test))
                     (info "Clocks reset")
                     (net/heal! (:net test) test)
                     (info "Network healed")
-                    (c/on-nodes test (partial start! clock))
+                    (c/on-nodes test (partial mc/start! clock))
                     (info "Nodes restarted")))))
 
     (teardown! [this test]

--- a/src/jepsen/mongodb/dbutil.clj
+++ b/src/jepsen/mongodb/dbutil.clj
@@ -1,0 +1,174 @@
+(ns jepsen.mongodb.dbutil
+  "Utility functions for initializing and finalizing a MongoDB database's
+  environment."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.logging :refer [info]]
+            [jepsen.control :as c]
+            [jepsen.control.util :as cu]
+            [jepsen.store :as store]
+            [jepsen.util :as util]
+            [jepsen.mongodb.control :as mcontrol]
+            [jepsen.mongodb.util :as mu])
+  (:import (java.nio.file CopyOption)
+           (java.nio.file Files)
+           (java.nio.file StandardCopyOption)))
+
+(defn- upload!
+  "Uploads the `local` file to the `remote` file location."
+  [test [local remote]]
+  (info "uploading" local "to" remote)
+  (if (= :vm (:virt test))
+    (c/upload local remote :mode 0755)
+    (Files/copy (.toPath (io/file local))
+                (.toPath (io/file remote))
+                (into-array CopyOption
+                            [StandardCopyOption/COPY_ATTRIBUTES
+                             StandardCopyOption/REPLACE_EXISTING]))))
+
+(defn- install-local-directory!
+  "Uploads MongoDB binaries from a local directory."
+  [test node dir]
+  ; Create the bin/ directory.
+  (mcontrol/exec test :mkdir :-p (mu/path-prefix test node "/bin"))
+
+  ; Upload the mongod binary and potentially also the mongobridge binary, if we
+  ; aren't running with any virtualization.
+  (->> (cond-> [[(str dir "/mongod")
+                 (mu/path-prefix test node "/bin/mongod")]]
+         (= :none (:virt test))
+         (conj [(str dir "/mongobridge")
+                (mu/path-prefix test node "/bin/mongobridge")]))
+       (map (partial upload! test))
+       dorun))
+
+(defn- install-local-tarball!
+  "Extracts MongoDB binaries from an already present tarball."
+  [test node file]
+  ; Extract the tarball into the /opt/mongodb/ directory.
+  (c/exec :tar :xvf file :-C (mu/path-prefix test node)
+          :--strip-components=1))
+
+; The install-remote-tarball! is mutually recursive with the install-binaries!
+; function so we need to forward declare one of them.
+(declare install-binaries!)
+
+(defn- install-remote-tarball!
+  "Downloads and extracts MongoDB binaries from a remote URL."
+  [test node url]
+  (when (= :none (:virt test))
+    (throw (IllegalStateException.
+             (str "The jepsen.control.util/wget! function cannot be used to"
+                  " download a tarball locally. Please consider using the"
+                  " --mongodb-dir command line option to refer to an existing"
+                  " checkout of the mongodb/mongo repository with binaries"
+                  " installed in the root directory."))))
+
+  (let [file (c/cd "/tmp" (str "/tmp/" (cu/wget! url)))]
+    (try
+      ; Extract the tarball into the /opt/mongodb/ directory.
+      (c/exec :tar :xvf file :-C (mu/path-prefix test node)
+              :--strip-components=1)
+
+      (catch RuntimeException e
+        (condp re-find (.getMessage e)
+          #"tar: Unexpected EOF"
+          (do (info "Retrying corrupt tarball download")
+              (c/exec :rm :-rf file)
+              (install-binaries! test node url))
+
+          ; If it was some other kind of error, then we rethrow it.
+          (throw e))))))
+
+(defn- install-binaries!
+  "Installs the MongoDB binaries into the node's directory from a local
+  directory, a local tarball, or a remote tarball."
+  [test node url]
+  ; Clean up the node's directory from a prior execution of the test.
+  (mcontrol/exec test :rm :-rf (mu/path-prefix test node))
+
+  ; Create the data/ directory.
+  (mcontrol/exec test :mkdir :-p (mu/path-prefix test node "/data"))
+
+  ; Install the MongoDB binaries into the node's directory.
+  (if-let [path (nth (re-find #"file://(.+)" url) 1)]
+    (if (.isDirectory (io/file path))
+      (install-local-directory! test node path)
+      (install-local-tarball! test node path))
+    (install-remote-tarball! test node url)))
+
+(defn install!
+  "Installs the MongoDB binaries into the node's directory from a local
+  directory, a local tarball, or a remote tarball. Also creates a new user who
+  owns the node's directory when running with some form of virtualization."
+  [test node url]
+  ; Add the "mongodb" user unless we are running without any virtualization.
+  (when (= :vm (:virt test))
+    (cu/ensure-user! (:username test)))
+
+  (mu/maybe-su test (install-binaries! test node url))
+
+  ; Set the permissions of the node's directory so that the "mongodb" user
+  ; owns its contents unless we are running with out any virtualization.
+  (when (= :vm (:virt test))
+    (c/exec :chown :-R (str (:username test) ":" (:username test))
+                       (mu/path-prefix test node))))
+
+(defn- log-files
+  [test node]
+  (cond-> [(mu/path-prefix test node "/stdout.log")
+           (mu/path-prefix test node "/mongod.log")]
+    (= :none (:virt test)) (conj (mu/path-prefix test node "/bridge.log"))))
+
+(defn- strip-leading-slash
+  "Removes the leading / from a pathname."
+  [path]
+  (str/replace path #"^/" ""))
+
+(defn- remote-download!
+  "Downloads the `remote` file to the `local` file location."
+  [test node remote local]
+  (info "downloading" remote "to" local)
+  (try
+    (->> local
+         strip-leading-slash
+         (store/path! test (name node))
+         .getCanonicalPath
+         (c/download remote))
+    (catch java.io.IOException e
+      (if (= "Pipe closed" (.getMessage e))
+        (info remote "pipe closed")
+        (throw e)))
+    (catch java.lang.IllegalArgumentException e
+      ; This is a JSch bug where the file is just being created.
+      (info remote "doesn't exist"))))
+
+(defn- local-copy!
+  "Copies the `src` file to the `dest` file location."
+  [test node src dest]
+  (info "copying" src "to" dest)
+  (try
+    (->> dest
+         strip-leading-slash
+         (store/path! test (name node))
+         (io/copy (io/file src)))
+    (catch java.io.FileNotFoundException e
+      (info src "doesn't exist"))))
+
+;; Adapted from the jepsen.core/snarf-logs! function of Jepsen version 0.1.8
+;; with support added to copy files locally to account for the possibility of
+;; running without any virtualization.
+(defn snarf-logs!
+  "Downloads logs for a node."
+  [test node]
+  (let [full-paths (log-files test node)
+        ; A map of full paths to short paths.
+        paths      (->> full-paths
+                        (map #(str/split % #"/"))
+                        util/drop-common-proper-prefix
+                        (map (partial str/join "/"))
+                        (zipmap full-paths))]
+    (doseq [[src dest] paths]
+      (if (= :vm (:virt test))
+        (remote-download! test node src dest)
+        (local-copy! test node src dest)))))

--- a/src/jepsen/mongodb/document_cas.clj
+++ b/src/jepsen/mongodb/document_cas.clj
@@ -132,7 +132,7 @@
                                (gen/stagger 1))
             :model        (model/cas-register)
             :checker      (checker/compose
-                            {:linear  (independent/checker checker/linearizable)
+                            {:linear  (independent/checker (checker/linearizable))
                              :timeline (independent/checker (timeline/html))
                              :perf     (checker/perf)})}
            opts)))

--- a/src/jepsen/mongodb/faketime.clj
+++ b/src/jepsen/mongodb/faketime.clj
@@ -1,68 +1,93 @@
 (ns jepsen.mongodb.faketime
   "Functions for messing with time and clocks."
   (:require [clj-time.core :as time]
+            [clojure.java.io :as io]
             [jepsen.control :as c]
-            [jepsen.mongodb.time :as mt])
+            [jepsen.mongodb.time :as mt]
+            [jepsen.mongodb.util :as mu])
   (:import (java.nio.charset Charset)
+           (java.nio.file CopyOption)
            (java.nio.file Files)
            (java.nio.file OpenOption)
+           (java.nio.file StandardCopyOption)
            (java.nio.file StandardOpenOption)
            (java.nio.file.attribute FileAttribute)
            (java.nio.file.attribute PosixFilePermissions)
            (org.joda.time Period)))
 
+(defn- faketime-timestamp-file
+  [test node]
+  (mu/path-prefix test node "/faketimerc"))
+
 (defn- upload-faketimerc!
-  "Updates the /opt/jepsen/faketimerc configuration file."
-  [^Period offset]
-  (c/su
-    (let [tmp-file
-          (Files/createTempFile
-            "jepsen-upload"
-            ".faketimerc"
-            (into-array FileAttribute [(PosixFilePermissions/asFileAttribute
-                                         (PosixFilePermissions/fromString
-                                           "rw-r--r--"))]))]
-      (try
-        (Files/write tmp-file
-                     ; libfaketime requires a leading '+' for setting offsets
-                     ; ahead of the true time.
-                     [(format "%+d" (time/in-seconds offset))]
-                     (Charset/defaultCharset)
-                     (into-array OpenOption [StandardOpenOption/WRITE]))
-        ; Upload
-        (c/exec :mkdir :-p "/opt/jepsen")
-        (c/exec :chmod "a+rwx" "/opt/jepsen")
-        (c/upload (str tmp-file) "/opt/jepsen/faketimerc")
-        (finally
-          (Files/delete tmp-file))))))
+  "Updates the faketimerc configuration file."
+  [test ^Period offset]
+  (let [dest     (faketime-timestamp-file test c/*host*)
+        tmp-file (Files/createTempFile
+                   "jepsen-upload"
+                   ".faketimerc"
+                   (into-array FileAttribute
+                               [(PosixFilePermissions/asFileAttribute
+                                  (PosixFilePermissions/fromString
+                                    "rw-r--r--"))]))]
+    (try
+      (Files/write tmp-file
+                   ; libfaketime requires a leading '+' for setting offsets
+                   ; ahead of the true time.
+                   [(format "%+d" (time/in-seconds offset))]
+                   (Charset/defaultCharset)
+                   (into-array OpenOption [StandardOpenOption/WRITE]))
+
+      ; Swap the faketimerc configuration file such that its contents are
+      ; atomically made visible to the underlying process.
+      (if (= :vm (:virt test))
+        ; If we're running with some form of virtualization, then we first
+        ; upload the faketimerc configuration file to the remote host (via SCP)
+        ; using its temporary name, and then atomically rename it to the
+        ; FAKETIME_TIMESTAMP_FILE name.
+        (let [tmp-file-dest
+              (mu/path-prefix test c/*host* (str "/" (.getFileName tmp-file)))]
+          (do (c/upload (str tmp-file) tmp-file-dest)
+              (c/exec :mv :-f tmp-file-dest dest)))
+
+        ; If we're running without any virtualization, then we just atomically
+        ; rename it to the FAKETIME_TIMESTAMP_FILE name.
+        (Files/move tmp-file
+                    (.toPath (io/file dest))
+                    (into-array CopyOption
+                                [StandardCopyOption/ATOMIC_MOVE
+                                 StandardCopyOption/REPLACE_EXISTING])))
+      (finally
+        (Files/deleteIfExists tmp-file)))))
 
 (defn- add-periods [a b] (.plus (.toPeriod a) (.toPeriod b)))
 
 (defn clock
   "Performs clock skewing using libfaketime and its file-based configuration
   mechanism."
-  ([{:keys [libfaketime-path]}]
-   (let [state (atom {})
-         true-time (time/seconds 0)]
-     (reify mt/Clock
-       (init! [clock]
-         (swap! state assoc c/*host* (atom true-time))
-         ; We reset the faketimerc configuration file when initializing the clock
-         ; to avoid causing heartbeat requests to time out spuriously when
-         ; initiating the replica set.
-         (upload-faketimerc! true-time))
+  [{:keys [libfaketime-path]}]
+  (let [state (atom {})
+        true-time (time/seconds 0)]
+    (reify mt/Clock
+      (init! [clock test]
+        (swap! state assoc c/*host* (atom true-time))
+        ; We reset the faketimerc configuration file when initializing the clock
+        ; to avoid causing heartbeat requests to time out spuriously when
+        ; initiating the replica set.
+        (upload-faketimerc! test true-time))
 
-       (wrap! [clock bin]
-         (conj ["/usr/bin/env"
-                "FAKETIME_NO_CACHE=1"
-                "FAKETIME_TIMESTAMP_FILE=/opt/jepsen/faketimerc"
-                (format "LD_PRELOAD=%s" libfaketime-path)]
-                bin))
+      (wrap! [clock test bin]
+        (conj ["/usr/bin/env"
+               "FAKETIME_NO_CACHE=1"
+               (format "FAKETIME_TIMESTAMP_FILE=%s"
+                       (faketime-timestamp-file test c/*host*))
+               (format "LD_PRELOAD=%s" libfaketime-path)]
+               bin))
 
-       (bump-time! [clock delta]
-         (upload-faketimerc! (swap! (get @state c/*host*)
-                                    (partial add-periods delta))))
+      (bump-time! [clock test delta]
+        (upload-faketimerc! test (swap! (get @state c/*host*)
+                                        (partial add-periods delta))))
 
-       (reset-time! [clock]
-         (upload-faketimerc! (swap! (get @state c/*host*)
-                                    (constantly true-time))))))))
+      (reset-time! [clock test]
+        (upload-faketimerc! test (swap! (get @state c/*host*)
+                                        (constantly true-time)))))))

--- a/src/jepsen/mongodb/mongo.clj
+++ b/src/jepsen/mongodb/mongo.clj
@@ -36,6 +36,13 @@
       (.connectTimeout           60000)
       (.socketTimeout            30000))))
 
+(defn server-address
+  ([node]
+   (ServerAddress. (name node)))
+
+  ([node port]
+   (ServerAddress. (name node) port)))
+
 (defn client
   "Creates a new Mongo client."
   [node]
@@ -44,7 +51,7 @@
 (defn cluster-client
   "Returns a mongoDB connection for all nodes in a test."
   [test]
-  (MongoClient. (->> test :nodes (map #(ServerAddress. (name %))))
+  (MongoClient. (->> test :nodes (map server-address))
                 (default-client-options)))
 
 (defn ^MongoDatabase db

--- a/src/jepsen/mongodb/net.clj
+++ b/src/jepsen/mongodb/net.clj
@@ -1,0 +1,84 @@
+(ns jepsen.mongodb.net
+  "MongoDB specific controls for network manipulation."
+  (:require [clj-time.core :as time]
+            [jepsen.net :as net]
+            [jepsen.util :refer [real-pmap]]
+            [jepsen.mongodb.mongo :as m]
+            [clojure.tools.logging :refer [info warn]])
+  (:import (org.joda.time Period)))
+
+(def ^:private clients
+  "A cache for the MongoClients used by the `mongobridge` network manipulator."
+  (atom nil))
+
+(defn- create-clients
+  "Given a collection `nodes`, returns a hash-map with keys equal to the nodes
+  and values equals to a MongoClient instance to the associated node."
+  [nodes]
+  (into {} (map #(vector % (m/client %))) nodes))
+
+(defn- get-or-create-clients
+  "Given a collection `nodes`, returns a hash-map with keys equal to the nodes
+  and values equals to a MongoClient instance to the associated node. This
+  function guarantees that a MongoClient instance will be constructed exactly
+  once for each node regardless of how many times it is called."
+  [nodes]
+  (while (nil? @clients)
+    (compare-and-set! clients nil (delay (create-clients nodes))))
+  (force @clients))
+
+(defn- run-bridge-command
+  [test node command-name & command-args]
+  (let [client (get (get-or-create-clients (:nodes test)) node)]
+    (try
+      (info "running bridge command" node command-name command-args)
+      (apply m/run-command!
+             (m/db client "test")
+             (concat `(~command-name 1 "$forBridge" true) command-args))
+      (catch com.mongodb.MongoSocketException e
+        (warn "bridge command failed likely due to node being killed"
+              node command-name command-args (.getMessage e)))
+      (catch com.mongodb.MongoTimeoutException e
+        (warn "bridge command failed likely due to node being killed"
+              node command-name command-args (.getMessage e))))))
+
+(def mongobridge
+  "Uses mongobridge to do network manipulation."
+  (reify net/Net
+    (drop! [net test src dest]
+      (run-bridge-command test
+                          dest
+                          :rejectConnectionsFrom
+                          :host (get (:bridge test) src)))
+
+    ; The "delayMessagesFrom" command implicitly undoes the effects of an
+    ; earlier "rejectConnectionsFrom" command by changing mongobridge's mode to
+    ; forward the message with an optional delay.
+    (heal! [net test] (net/fast! net test))
+
+    (slow! [net test] (net/slow! net test {}))
+    (slow! [net test {:keys [^Period mean], :or {mean (time/millis 50)}}]
+      (->> (for [src  (vals (:bridge test))
+                 dest (keys (:bridge test))]
+             [src dest])
+           (real-pmap (fn [[src dest]]
+                        (run-bridge-command test
+                                            dest
+                                            :delayMessagesFrom
+                                            :host src
+                                            :delay (time/in-millis mean))))
+           dorun))
+
+    (flaky! [net test]
+      (->> (for [src  (vals (:bridge test))
+                 dest (keys (:bridge test))]
+             [src dest])
+           (real-pmap (fn [[src dest]]
+                        (run-bridge-command test
+                                            dest
+                                            :discardMessagesFrom
+                                            :host src
+                                            :loss 0.2)))
+           dorun))
+
+    (fast! [net test] (net/slow! net test {:mean (time/millis 0)}))))

--- a/src/jepsen/mongodb/time.clj
+++ b/src/jepsen/mongodb/time.clj
@@ -6,35 +6,35 @@
 
 (defprotocol Clock
   (init!
-    [clock]
+    [clock test]
     "Initializes any internal structures for time keeping on the current host.")
 
   (wrap!
-    [clock bin]
+    [clock test bin]
     "Returns how to invoke the specified binary under the control of this
     clock.")
 
   (bump-time!
-    [clock ^Period delta]
+    [clock test ^Period delta]
     "Advances the current host's clock by the specified time period.")
 
-  (reset-time! [clock]
+  (reset-time! [clock test]
                "Resets the current host's clock back to the true time."))
 
 (defn noop-clock
   "Does nothing."
-  ([_]
-   (reify Clock
-     (init! [clock])
-     (wrap! [clock bin] [bin])
-     (bump-time! [clock delta])
-     (reset-time! [clock]))))
+  [_]
+  (reify Clock
+    (init! [clock test])
+    (wrap! [clock test bin] [bin])
+    (bump-time! [clock test delta])
+    (reset-time! [clock test])))
 
 (defn system-clock
   "Changes the system's time using settimeofday()."
-  ([_]
-   (reify Clock
-     (init! [clock])
-     (wrap! [clock bin] [bin])
-     (bump-time! [clock delta] (nt/bump-time! (time/in-millis delta)))
-     (reset-time! [clock] (nt/reset-time!)))))
+  [_]
+  (reify Clock
+    (init! [clock test])
+    (wrap! [clock test bin] [bin])
+    (bump-time! [clock test delta] (nt/bump-time! (time/in-millis delta)))
+    (reset-time! [clock test] (nt/reset-time!))))

--- a/src/jepsen/mongodb/util.clj
+++ b/src/jepsen/mongodb/util.clj
@@ -1,0 +1,24 @@
+(ns jepsen.mongodb.util
+  "Utility functions."
+  (:require [jepsen.control :as c]))
+
+(defmacro maybe-sudo
+  "Evaluates forms with a particular user unless `test` is running without any
+  virtualization."
+  [test user & body]
+  `(if (= :vm (:virt ~test))
+     (c/sudo ~user ~@body)
+     ~@body))
+
+(defmacro maybe-su
+  "sudo root ... unless `test` is running without any virtualization."
+  [test & body]
+  `(if (= :vm (:virt ~test))
+     (c/su ~@body)
+     ~@body))
+
+(defn path-prefix
+  "Returns the subdirectory of the working directory that should be used for the
+  node's data directory"
+  [test node & suffixes]
+  (apply str (:working-dir test) "/" (name node) suffixes))

--- a/test/jepsen/control/local_test.clj
+++ b/test/jepsen/control/local_test.clj
@@ -1,0 +1,11 @@
+(ns jepsen.control.local-test
+  "Tests for the jepsen.control.local namespace."
+  (:require [clojure.test :refer :all]
+            [jepsen.control :as c]
+            [jepsen.control.local :as clocal]))
+
+(deftest echo-message
+  (is (= "hello there" (clocal/exec :echo "hello there"))))
+
+(deftest change-directory
+  (is (= "/tmp" (c/cd "/tmp" (clocal/exec :pwd)))))


### PR DESCRIPTION
* Moves process management related code into a separate `jepsen.mongodb.cluster` namespace. This namespace defines multimethods for each of the `init!`, `start!`, `stop!`, and `kill!` behaviors, and has methods associated with the `:none` and `:vm` virtualization options.

* Adds support for spawning mongobridge processes to do the network partitioning.

* Exposes a `--working-dir` option to have Jepsen extract the MongoDB binaries and write faketimerc configuration files into a directory other than `/opt/mongodb/` (or `/opt/jepsen/`).

* Exposes a `--mongodb-dir` option to have Jepsen install the MongoDB binaries from an existing checkout of the mongodb/mongo repository, or from an already extracted tarball.

* Also changes `jepsen.mongodb.faketime/upload-faketimerc!` to swap the faketimerc configuration file via an atomic rename. This eliminates the risk where the libfaketime library could misbehave if the new faketimerc configuration file had been partially written when read by a thread in mongod.

----

@aphyr, I managed to find some time to integrate mongobridge into our Jepsen tests to replace our usage of iptables for doing the network partitioning. As we had previously discussed via email, this was the main piece preventing us from running the entire MongoDB deployment on a single machine without using LXC containers (we're already using libfaketime to simulate clock skew).

If you're curious to know more about mongobridge, the closest thing to public documentation we have around it is from [its JavaScript API](https://github.com/mongodb/mongo/blob/r3.7.2/src/mongo/shell/bridge.js) and the code itself lives in [bridge.cpp](https://github.com/mongodb/mongo/blob/r3.7.2/src/mongo/tools/bridge.cpp).

**How I tested my changes**

- [x] Verified that I could successfully run

```
lein run test --test register --node ... -z none -c none
lein run test --test set --node ... -z none -c faketime
lein run test --test set -z lxc -c none
```