### PR TITLE
Fixed small mistake?

### DIFF
--- a/src/jepsen/mongodb/set.clj
+++ b/src/jepsen/mongodb/set.clj
@@ -65,7 +65,7 @@
                           ; reads
                           (gen/limit 2 {:type :invoke, :f :read, :value nil}))
        :checker (checker/compose
-                  {:set      checker/set
+                  {:set      (checker/set)
                    :timeline (timeline/html)
                    :perf     (checker/perf)})}
       opts)))


### PR DESCRIPTION
Hi @aphyr ,

I'm doing some work for a professor who is investigating network partitions and distributed systems. 

I was playing around with the mongodb tests, and this seems to be a small mistake that I found where `checker/set` is not actually called when we create the checkers for this specific test.

Any thoughts?