### PR TITLE
Add DONT_FAKE_MONOTONIC=1 to libfaketime configuration

### DIFF
--- a/src/jepsen/mongodb/faketime.clj
+++ b/src/jepsen/mongodb/faketime.clj
@@ -78,6 +78,7 @@
 
       (wrap! [clock test bin]
         (conj ["/usr/bin/env"
+               "DONT_FAKE_MONOTONIC=1"
                "FAKETIME_NO_CACHE=1"
                (format "FAKETIME_TIMESTAMP_FILE=%s"
                        (faketime-timestamp-file test c/*host*))


### PR DESCRIPTION
@aphyr, there's a couple other changes we've made internally that I'll try and get upstreamed in the next day or two. (Hope I'm not disrupting your vacation too much!)

The changes from [SERVER-31215](https://jira.mongodb.org/browse/SERVER-31215) and [WT-3461](https://jira.mongodb.org/browse/WT-3461) made it so that `pthread_cond_timedwait()` calls in WiredTiger use the monotonic clock if possible. Without setting the `DONT_FAKE_MONOTONIC` environment variable, the libfaketime library would permit the monotonic clock to go arbitrarily backwards and lead to hangs with WiredTiger waiting on a condition variable set for "a very long time". CC @sueloverso