### PR TITLE
Run dbhash check at end of the test

### DIFF
--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -29,6 +29,7 @@
             [jepsen.os.debian :as debian]
             [jepsen.mongodb.cluster :as mc]
             [jepsen.mongodb.control :as mcontrol]
+            [jepsen.mongodb.dbhash :as dbhash]
             [jepsen.mongodb.dbutil :as mdbutil]
             [jepsen.mongodb.mongo :as m]
             [jepsen.mongodb.net :as mnet]
@@ -458,7 +459,13 @@
   :tarball            HTTP URL of a tarball to install
   :time-limit         How long do we run the test for?
   :storage-engine     Storage engine to use
-  :protocol-version   Replication protocol version"
+  :protocol-version   Replication protocol version
+
+  At the end of every test, we use the 'dbHash' command to verify data
+  consistency across each member of the replica set. We extend the nemesis to
+  handle the :compare-dbhashes operations because it is a client that is
+  straightforward to compose via the `jepsen.nemesis/compose` function. We also
+  extend the generator and checker accordingly."
   [name opts]
   (merge
     (assoc tests/noop-test
@@ -466,7 +473,13 @@
                                  " p:" (:protocol-version opts))
            :os              debian/os
            :db              (db (:clock opts) (:tarball opts))
-           :nemesis         (primary-divergence-nemesis (:clock opts))
+           :nemesis         (nemesis/compose
+                              ; We allow for dbhash checks by composing our
+                              ; standard "chaos" nemesis with a client that
+                              ; handles :compare-dbhashes ops.
+                              {#{:isolate :kill :stop}
+                               (primary-divergence-nemesis (:clock opts))
+                               #{:compare-dbhashes} dbhash/client})
            :generator       (gen/phases
                               (->> (:generator opts)
                                    (gen/nemesis (primary-divergence-gen))
@@ -474,9 +487,17 @@
                               (gen/nemesis
                                 (gen/once {:type :info, :f :stop, :value nil}))
                               (gen/sleep 40)
-                              (gen/clients
-                                (:final-generator opts))))
+                              (gen/clients (:final-generator opts))
+                              ; Generate the :compare-dbhashes op at the very
+                              ; end of the test.
+                              (gen/nemesis dbhash/gen))
+           :client            (:client opts)
+           :checker           (checker/compose
+                                {:base (:checker opts)
+                                 :dbhash dbhash/checker}))
     (dissoc opts
+            :checker
+            :client
             :generator
             :final-generator
             :clock)))

--- a/src/jepsen/mongodb/dbhash.clj
+++ b/src/jepsen/mongodb/dbhash.clj
@@ -1,0 +1,80 @@
+(ns jepsen.mongodb.dbhash
+  "Client, generator, and checker for verifying data consistency across all
+  members of a replica set by using the 'dbHash' command."
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :refer [error]]
+            [jepsen.checker :as checker]
+            [jepsen.client :as client]
+            [jepsen.control :as c]
+            [jepsen.generator :as gen]
+            [jepsen.mongodb.control :as mcontrol]
+            [jepsen.mongodb.mongo :as m]
+            [jepsen.mongodb.util :as mu]))
+
+(defn- mongo-shell-command [node]
+  "Returns a series of JavaScript statements in their stringified form for
+  performing a dbhash check against a replica set. We make sure the replica set
+  has stabilized with node #0 as the primary because our Jepsen tests give node
+  #0 the highest priority."
+  (->> [(format "var rst = new ReplSetTest('%s')" (str (m/server-address node)))
+        "rst.waitForState(rst.nodes[0], ReplSetTest.State.PRIMARY)"
+        "rst.checkReplicatedDataHashes()"]
+       (str/join "; ")))
+
+(defn- check-replica-set!
+  "Performs a dbhash check against the test's replica set. This function returns
+  an updated op indicating whether the dbhash check succeeded or failed."
+  [test op]
+  ; We use the first node as the seed node to ReplSetTest.
+  (let [node (first (:nodes test))]
+    (try
+      ; If the dbhash check fails, then a JavaScript exception will be thrown,
+      ; which in turn will cause the mongo shell to exist with a non-zero return
+      ; code and `jepsen.mongodb.control/exec` to throw a RuntimeException.
+      (c/with-session node (get (:sessions test) node)
+        (->> node
+             mongo-shell-command
+             (mcontrol/exec test
+               (mu/path-prefix test node "/bin/mongo")
+               :--nodb :--quiet :--eval)))
+
+      (assoc op :result :valid)
+      (catch RuntimeException e
+        ; Capture the mongo shell's output on failure.
+        (assoc op
+               :result :invalid
+               :fail-msg (.getMessage e))))))
+
+(def gen
+  "Generator for the :compare-dbhashes operation."
+  (gen/once {:type :info, :f :compare-dbhashes, :value nil}))
+
+(def client
+  "Client that runs the dbhash check against a replica set."
+  (reify client/Client
+    (open! [client test node] client)
+    (close! [client test])
+    (setup! [client test])
+    (invoke! [client test op]
+      (when (= :compare-dbhashes (:f op))
+        (check-replica-set! test op)))
+    (teardown! [client test])))
+
+(def checker
+  "Checker for reporting the results of the dbhash check."
+  (reify checker/Checker
+    (check [this test model history opts]
+      (if-let [dbhash-result
+               (->> history
+                    (filter (fn [op] (= :compare-dbhashes (:f op))))
+                    ; We only want the result.
+                    (filter (fn [op] (contains? op :result)))
+                    ; Will be nil if the op doesn't exist.
+                    first)]
+        (case (:result dbhash-result)
+          :valid    {:valid? true}
+          :invalid  (do (error "dbhash check failed" (:fail-msg dbhash-result))
+                        {:valid? false
+                         :error  (str "see the earlier 'dbhash check failed'"
+                                      " message in the logs along with the"
+                                      " mongo shell's output")}))))))

--- a/src/jepsen/mongodb/dbutil.clj
+++ b/src/jepsen/mongodb/dbutil.clj
@@ -32,10 +32,12 @@
   ; Create the bin/ directory.
   (mcontrol/exec test :mkdir :-p (mu/path-prefix test node "/bin"))
 
-  ; Upload the mongod binary and potentially also the mongobridge binary, if we
-  ; aren't running with any virtualization.
+  ; Upload the mongod and mongo shell binaries. The mongobridge binary is also
+  ; uploaded if we aren't running with any virtualization.
   (->> (cond-> [[(str dir "/mongod")
-                 (mu/path-prefix test node "/bin/mongod")]]
+                 (mu/path-prefix test node "/bin/mongod")]
+                [(str dir "/mongo")
+                 (mu/path-prefix test node "/bin/mongo")]]
          (= :none (:virt test))
          (conj [(str dir "/mongobridge")
                 (mu/path-prefix test node "/bin/mongobridge")]))


### PR DESCRIPTION
The `ReplSetTest#checkReplicatedDataHashes()` function uses the "dbHash" command to verify that the contents of all collections are the same across all members of the replica set. It is one of the data consistency checks we commonly use to test that data replication is correct. CC @will62794 