### PR TITLE
Use jepsen.nemesis.Nemesis instance for dbhash checker

### DIFF
--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -487,7 +487,7 @@
                       ;; handles :compare-dbhashes ops.
                       {#{:isolate :kill :stop}
                        (primary-divergence-nemesis (:clock opts))
-                       #{:compare-dbhashes} dbhash/client})
+                       #{:compare-dbhashes} dbhash/nemesis})
           :generator (gen/phases
                       (->> (:generator opts)
                            (gen/nemesis (primary-divergence-gen))

--- a/src/jepsen/mongodb/dbhash.clj
+++ b/src/jepsen/mongodb/dbhash.clj
@@ -7,6 +7,7 @@
             [jepsen.client :as client]
             [jepsen.control :as c]
             [jepsen.generator :as gen]
+            [jepsen.nemesis :as nemesis]
             [jepsen.mongodb.control :as mcontrol]
             [jepsen.mongodb.mongo :as m]
             [jepsen.mongodb.util :as mu]))
@@ -50,7 +51,8 @@
   (gen/once {:type :info, :f :compare-dbhashes, :value nil}))
 
 (def client
-  "Client that runs the dbhash check against a replica set."
+  "Client that implements the jepsen.client/Client protocol and runs the dbhash
+  check against a replica set."
   (reify client/Client
     (open! [client test node] client)
     (close! [client test])
@@ -59,6 +61,16 @@
       (when (= :compare-dbhashes (:f op))
         (check-replica-set! test op)))
     (teardown! [client test])))
+
+(def nemesis
+  "Client that implements the jepsen.nemesis/Nemesis protocol and runs the
+  dbhash check against a replica set."
+  (reify nemesis/Nemesis
+    (setup! [nemesis test] nemesis)
+    (invoke! [nemesis test op]
+      (when (= :compare-dbhashes (:f op))
+        (check-replica-set! test op)))
+    (teardown! [nemesis test])))
 
 (def checker
   "Checker for reporting the results of the dbhash check."


### PR DESCRIPTION
Due to the issue described in jepsen-io/jepsen#245, the changes from 58909081221d379aab79a5a26a1d227d57f2480c as part of #13 caused `jepsen.mongodb.core/primary-divergence-nemesis` to silently do nothing in its `invoke!` method because `conns` is always `nil`. The changes proposed here work around the issue with composing new-style `jepsen.client.Client` instances by using a `jepsen.nemesis.Nemesis` version of the dbhash checker in the composition instead. CC @mkcp

**How I tested my changes**

- [x] Verified when running `lein run test --test set` that the "believes itself a primary" message actually shows up in the logs.

----

I'd also like to be able to add the following invariant to `jepsen.mongodb.core/primary-divergence-nemesis`; however, the `AssertionError` exceptions are caught and logged by [this logic](https://github.com/jepsen-io/jepsen/blob/0.1.8/jepsen/src/jepsen/core.clj#L293-L295), so I'm not sure of a way to cause Jepsen to abort from inside the nemesis.

```diff
diff --git a/src/jepsen/mongodb/core.clj b/src/jepsen/mongodb/core.clj
index 2de7284..4b5e7cd 100644
--- a/src/jepsen/mongodb/core.clj
+++ b/src/jepsen/mongodb/core.clj
@@ -406,6 +406,9 @@
         (into {} (real-pmap (juxt identity await-conn) (:nodes test)))))

     (invoke! [this test op]
+      (assert (some? conns)
+              (str "setup! either has not been called, or the result of calling"
+                   " setup! has not been properly saved"))
       (assoc
         op :value
         (case (:f op)
```